### PR TITLE
Agregada ruta para obtener el url de login a zimbra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+.DS_Store
+.idea

--- a/app.rb
+++ b/app.rb
@@ -14,5 +14,13 @@ class App < Sinatra::Base
     json user.marshal_dump
   end
 
+  post '/url' do
+    user = ZimbraPreauthService.user_info params[:email]
+    url = OpenStruct.new(
+        mail_login_url: user.mail_login_url
+    )
+    json url.marshal_dump
+  end
+
   run! if app_file == $0
 end

--- a/lib/zimbra_preauth_service.rb
+++ b/lib/zimbra_preauth_service.rb
@@ -75,7 +75,7 @@ module ZimbraPreauthService
         first_name: ldap_data(user['givenname']),
         preauth_token: preauth_token,
         domain: login_email.split(/@/)[1],
-        default_team: login_email.split(/@/)[1].gsub(/\./, '_'),
+        default_team: login_email.split(/@/)[1].gsub(/\./, '-'),
         mail_login_url: build_login_url(login_email, preauth_token)
       )
     end


### PR DESCRIPTION
Creada una ruta para que se pueda obtener el mail_login_url, de lo contrario el mismo expiraba y al estar autenticado con el oauth de zbox arrojaba un error 400 al tratar de ingresar a zimbra
